### PR TITLE
Remove 'version' attribute

### DIFF
--- a/drupal/docker-compose.yml
+++ b/drupal/docker-compose.yml
@@ -10,8 +10,6 @@
 # Database password: example
 # ADVANCED OPTIONS; Database host: postgres
 
-version: '3.1'
-
 services:
 
   drupal:


### PR DESCRIPTION
The attribute 'version' is obsolete and is ignored. Docker recommends to remove it to avoid potential confusion.